### PR TITLE
Fix mkdocs script path

### DIFF
--- a/mkdocs-env/bin/mkdocs
+++ b/mkdocs-env/bin/mkdocs
@@ -3,7 +3,13 @@
 import re
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib', 'python3.12', 'site-packages'))
+_env_lib = os.path.join(os.path.dirname(__file__), '..', 'lib')
+if os.path.isdir(_env_lib):
+    for _name in os.listdir(_env_lib):
+        _cand = os.path.join(_env_lib, _name, 'site-packages')
+        if os.path.isdir(_cand):
+            sys.path.insert(0, _cand)
+            break
 from mkdocs.__main__ import cli
 if __name__ == '__main__':
     sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])

--- a/mkdocs-env/bin/mkdocs
+++ b/mkdocs-env/bin/mkdocs
@@ -1,7 +1,9 @@
-#!/home/leonard.ziserman/perso/php_doc_pub/mkdocs-env/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import re
 import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib', 'python3.12', 'site-packages'))
 from mkdocs.__main__ import cli
 if __name__ == '__main__':
     sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])


### PR DESCRIPTION
## Summary
- fix `mkdocs` script to use env `python3` and locate packages properly

## Testing
- `mkdocs-env/bin/mkdocs --version`


------
https://chatgpt.com/codex/tasks/task_e_68526da1f8e0832f9fa46774fe7d842d