### PR TITLE
Add documentation build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Documentation PHP et Symfony
+
+[![Documentation Build](https://github.com/owner/repo/actions/workflows/deploy.yml/badge.svg)](https://github.com/owner/repo/actions/workflows/deploy.yml)
+
+Ce dépôt contient la documentation générée avec MkDocs.

--- a/deploy.yml
+++ b/deploy.yml
@@ -20,6 +20,10 @@ jobs:
         run: |
           pip install -r requirements.txt
 
+      - name: Build documentation
+        run: mkdocs build --strict
+
       - name: Deploy to GitHub Pages
+        if: ${{ success() }}
         run: |
           mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- build MkDocs docs during CI
- only deploy after a successful build
- add README with a build status badge

## Testing
- `pip install -r requirements.txt`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_68527777744c832f93f182666db14740