### PR TITLE
Fix syntax highlighting

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,10 @@ theme:
   palette:
     scheme: slate
 
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+
 nav:
   - Accueil: '(php).md'
   - PHP:


### PR DESCRIPTION
## Summary
- enable pymdown extensions for code highlighting

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_685279f09dd8832f996f050fbcafa869