### PR TITLE
Add wikilinks plugin to mkdocs setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 [![Documentation Build](https://github.com/owner/repo/actions/workflows/deploy.yml/badge.svg)](https://github.com/owner/repo/actions/workflows/deploy.yml)
 
 Ce dépôt contient la documentation générée avec MkDocs.
+
+Le projet utilise le plugin **mkdocs-wikilinks-plugin** (via l'alias `ezlinks`)
+pour permettre les liens de type `[[Nom-de-page]]` dans la documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,9 @@ theme:
 markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
+plugins:
+  - search
+  - ezlinks
 
 nav:
   - Accueil: '(php).md'

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ requests==2.32.3
 six==1.17.0
 urllib3==2.4.0
 watchdog==6.0.0
+mkdocs-wikilinks-plugin==0.1.0


### PR DESCRIPTION
## Summary
- document wikilinks plugin usage
- enable ezlinks plugin for wikilinks
- add plugin to requirements

## Testing
- `mkdocs build -s`
- `mkdocs build -v 2>&1 | grep -n "plugins" | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_685285ec1de4832f93851fdbc74de53a